### PR TITLE
Removed unicode text that caused errors on ArchLinux on RPi 3

### DIFF
--- a/bme280/bme280.py
+++ b/bme280/bme280.py
@@ -217,12 +217,12 @@ def main():
     if args.humidity:
         print("%7.2f ％" % data_all.humidity)
     if args.temperature:
-        print("%7.2f ℃" % data_all.temperature)
+        print("%7.2f C" % data_all.temperature)
 
     if not args.pressure and not args.humidity and not args.temperature:
         print("%7.2f hPa" % data_all.pressure)
         print("%7.2f ％" % data_all.humidity)
-        print("%7.2f ℃" % data_all.temperature)
+        print("%7.2f C" % data_all.temperature)
 
 
 if __name__ == '__main__':

--- a/bme280/bme280.py
+++ b/bme280/bme280.py
@@ -221,7 +221,7 @@ def main():
 
     if not args.pressure and not args.humidity and not args.temperature:
         print("%7.2f hPa" % data_all.pressure)
-        print("%7.2f ％" % data_all.humidity)
+        print("%7.2f %" % data_all.humidity)
         print("%7.2f C" % data_all.temperature)
 
 

--- a/bme280/bme280.py
+++ b/bme280/bme280.py
@@ -221,7 +221,7 @@ def main():
 
     if not args.pressure and not args.humidity and not args.temperature:
         print("%7.2f hPa" % data_all.pressure)
-        print("%7.2f %" % data_all.humidity)
+        print("%7.2f %%" % data_all.humidity)
         print("%7.2f C" % data_all.temperature)
 
 


### PR DESCRIPTION
The characters for humidity and temperature caused the script to fail with an error on RPi 3. I replaced the characters with ASCII characters to ensure that they work correctly. 

Script is tested on RPi 3 with ArchLinux.
