### PR TITLE
Configurable bme280 instantiation parameters

### DIFF
--- a/bme280/bme280.py
+++ b/bme280/bme280.py
@@ -167,22 +167,24 @@ def compensate_humidity(adc_h):
     return var_h
 
 
-def setup(oversample_t=1, oversample_p=1, oversample_h=1, mode=0x3, t_sb=0x5, filter=0x0, spi3w_en=0x0):
+def setup(oversample_t=1, oversample_p=1, oversample_h=1, filter=0, mode=0x3, t_sb=0x5, spi3w_en=0x0):
     """
     Setup BME280 sensor by writing control/configuration registers
 
     oversample_t - Temperature oversampling factor
     oversample_p - Pressure oversampling factor
     oversample_h - Humidity oversampling factor
+    filter       - Sensor filtering factor
 
     Valid values for these parameters include:
-        0 = skip
+        0 = skip measurement/filter off
         1, 2, 4, 8, or 16
 
-    mode = 0x3  # Normal mode
-    t_sb = 0x5  # Tstandby 1000ms
-    filter = 0x0  # Filter off
-    spi3w_en = 0  # 3-wire SPI Disable
+    For remaining parameters, use raw register values, for example:
+
+    mode = 0x3    - Normal power mode
+    t_sb = 0x5    - Tstandby 1000ms
+    spi3w_en = 0  - 3-wire SPI Disable
     """
 
     global setup_run
@@ -211,6 +213,9 @@ def setup(oversample_t=1, oversample_p=1, oversample_h=1, mode=0x3, t_sb=0x5, fi
     osrs_p = osrs_values[oversample_p]
     osrs_h = osrs_values[oversample_h]
     filter = osrs_values[filter]
+
+    assert 0x0 <= mode <= 0x3
+
 
     ctrl_meas_reg = (osrs_t << 5) | (osrs_p << 2) | mode
     config_reg = (t_sb << 5) | (filter << 2) | spi3w_en

--- a/bme280/bme280.py
+++ b/bme280/bme280.py
@@ -189,7 +189,7 @@ def setup(oversample_t=1, oversample_p=1, oversample_h=1, mode=0x3, t_sb=0x5, fi
     if setup_run:
         return
 
-    # Oversampling register values (oversampling factor -> register value)
+    # Oversampling and filter register values (oversampling factor -> register value)
     osrs_values = {
         0: 0x0,
         1: 0x1,
@@ -204,10 +204,13 @@ def setup(oversample_t=1, oversample_p=1, oversample_h=1, mode=0x3, t_sb=0x5, fi
         raise ValueError("Invalid pressure oversampling value {:d}".format(oversample_p))
     if oversample_h not in osrs_values:
         raise ValueError("Invalid humidity oversampling value {:d}".format(oversample_h))
+    if filter not in osrs_values:
+        raise ValueError("Invalid filter setting {:d}".format(filter))
 
     osrs_t = osrs_values[oversample_t]
     osrs_p = osrs_values[oversample_p]
     osrs_h = osrs_values[oversample_h]
+    filter = osrs_values[filter]
 
     ctrl_meas_reg = (osrs_t << 5) | (osrs_p << 2) | mode
     config_reg = (t_sb << 5) | (filter << 2) | spi3w_en

--- a/bme280/bme280.py
+++ b/bme280/bme280.py
@@ -167,22 +167,56 @@ def compensate_humidity(adc_h):
     return var_h
 
 
-def setup():
+def setup(oversample_t=1, oversample_p=1, oversample_h=1, mode=0x3, t_sb=0x5, filter=0x0, spi3w_en=0x0):
+    """
+    Setup BME280 sensor by writing control/configuration registers
+
+    oversample_t - Temperature oversampling factor
+    oversample_p - Pressure oversampling factor
+    oversample_h - Humidity oversampling factor
+
+    Valid values for these parameters include:
+        0 = skip
+        1, 2, 4, 8, or 16
+
+    mode = 0x3  # Normal mode
+    t_sb = 0x5  # Tstandby 1000ms
+    filter = 0x0  # Filter off
+    spi3w_en = 0  # 3-wire SPI Disable
+    """
+
     global setup_run
     if setup_run:
         return
 
-    osrs_t = 1  # Temperature oversampling x 1
-    osrs_p = 1  # Pressure oversampling x 1
-    osrs_h = 1  # Humidity oversampling x 1
-    mode = 3  # Normal mode
-    t_sb = 5  # Tstandby 1000ms
-    filter = 0  # Filter off
-    spi3w_en = 0  # 3-wire SPI Disable
+    # Oversampling register values (oversampling factor -> register value)
+    osrs_values = {
+        0: 0x0,
+        1: 0x1,
+        2: 0x2,
+        4: 0x3,
+        8: 0x4,
+        16: 0x5,
+    }
+    if oversample_t not in osrs_values:
+        raise ValueError("Invalid temperature oversampling value {:d}".format(oversample_t))
+    if oversample_p not in osrs_values:
+        raise ValueError("Invalid pressure oversampling value {:d}".format(oversample_p))
+    if oversample_h not in osrs_values:
+        raise ValueError("Invalid humidity oversampling value {:d}".format(oversample_h))
+
+    osrs_t = osrs_values[oversample_t]
+    osrs_p = osrs_values[oversample_p]
+    osrs_h = osrs_values[oversample_h]
 
     ctrl_meas_reg = (osrs_t << 5) | (osrs_p << 2) | mode
     config_reg = (t_sb << 5) | (filter << 2) | spi3w_en
     ctrl_hum_reg = osrs_h
+
+    # The Adafruit Arduino BME280 library notes that:
+    # "making sure sensor is in sleep mode before setting configuration as it otherwise may be ignored."
+    # https://github.com/adafruit/Adafruit_BME280_Library/blob/e8a7e29df2862109247b7a3eb4f2b10381f4bab3/Adafruit_BME280.cpp#L165
+    bme280_i2c.write_byte_data(0xF4, 0x00)
 
     bme280_i2c.write_byte_data(0xF2, ctrl_hum_reg)
     bme280_i2c.write_byte_data(0xF4, ctrl_meas_reg)


### PR DESCRIPTION
Hi there,

I modified the code to allow the sensor to be initialized with non-default oversampling/filtering parameters.  Default behavior same as previously, but optional parameters are accepted.

My motivation was that I wanted to be able to initialize my bme280 with max oversampling.

I wasn't able to get virtualenv working from the contributing template, but I did test the code on my bme280 on raspberry pi setup.

From 
https://github.com/kbrownlees/bme280/blob/c3a24d0332893eddc95e38a9c98b1e4a8fd2799e/bme280/bme280.py#L207-L212

I called it in my code like this:
```
        bme280.bme280_i2c.set_default_i2c_address(args.i2caddr)
        bme280.bme280_i2c.set_default_bus(1)
        bme280.setup(oversample_t=16, oversample_p=16, oversample_h=16)
```

It's pretty quick and dirty so happy to take suggestions if you notice things that could be nicer. Possible room for improvement:
- Extend configurability out to command line arguments for `bme280.py`?
- Parameter naming?

